### PR TITLE
develop/BT-77:[FEAT] 이메일,닉네임,추가입력내용 완료 컴포넌트 추가

### DIFF
--- a/app/_layout.jsx
+++ b/app/_layout.jsx
@@ -2,7 +2,7 @@ import { Stack } from 'expo-router'
 
 export default function RootLayout() {
 	return (
-		<Stack>
+		<Stack screenOptions={{headerShown: false}}>
 			<Stack.Screen name="(tabs)" options={{ headerShown: false }} />
 			<Stack.Screen name="+not-found" />
 		</Stack>

--- a/app/login/login/login.jsx
+++ b/app/login/login/login.jsx
@@ -71,7 +71,7 @@ export default function LoginScreen() {
 					<View key={index} style={[styles.dot, currentSlide === index && styles.activeDot]} />
 				))}
 			</View>
-			<Link href="(tabs)/boongtam" asChild>
+			<Link href="/login/signup/loginNickname" asChild>
 				<Pressable style={styles.kakaoButton}>
 					<Image source={require('../../../assets/icon/kakao_login_medium_narrow.png')} style={styles.kakaoImage} />
 				</Pressable>

--- a/app/login/signup/loginAddress.jsx
+++ b/app/login/signup/loginAddress.jsx
@@ -5,6 +5,10 @@ import {
     TextInput,
     TouchableOpacity,
     StyleSheet,
+    KeyboardAvoidingView,
+    Platform,
+    TouchableWithoutFeedback,
+    Keyboard
 } from 'react-native';
 import { useRouter } from 'expo-router';
 import { MaterialIcons } from '@expo/vector-icons';
@@ -24,66 +28,74 @@ const AddressInput = () => {
     const isSkipButtonEnabled = address.length === MIN_ADDRESS_LENGTH && detailedAddress.length === MIN_ADDRESS_LENGTH;
 
     return (
-        <Container>
-            {/* 상단 네비게이션 */}
-            <View style={styles.header}>
-                <TouchableOpacity style={styles.backButton} onPress={() => router.back()}>
-                    <MaterialIcons name="arrow-back" size={24} color={Colors.gray500} />
-                </TouchableOpacity>
-                <Text style={styles.headerTitle}>{STRINGS.SIGNUP.TITLE}</Text>
-                <Text style={styles.pageIndicator}>3 / 3</Text>
-            </View>
+        <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+            <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : 'height'} style={styles.container}>
+                {/* 상단 네비게이션 */}
+                <View style={styles.header}>
+                    <TouchableOpacity style={styles.backButton} onPress={() => router.back()}>
+                        <MaterialIcons name="arrow-back" size={24} color={Colors.gray500} />
+                    </TouchableOpacity>
+                    <Text style={styles.headerTitle}>{STRINGS.SIGNUP.TITLE}</Text>
+                    <Text style={styles.pageIndicator}>3 / 3</Text>
+                </View>
 
-            {/* 주소 입력 */}
-            <View style={styles.addressSection}>
-                <Text style={styles.label}>주소</Text>
-                <TextInput
-                    style={styles.input}
-                    placeholder="주소"
-                    value={address}
-                    onChangeText={(text) => setAddress(text.trim())}
-                />
-                <TextInput
-                    style={styles.input}
-                    placeholder="상세주소"
-                    value={detailedAddress}
-                    onChangeText={(text) => setDetailedAddress(text.trim())}
-                />
-                <Text style={styles.helperText}>주소에 이모티콘은 사용할 수 없습니다.</Text>
-            </View>
+                {/* 주소 입력 */}
+                <View style={styles.addressSection}>
+                    <Text style={styles.label}>주소</Text>
+                    <TextInput
+                        style={styles.input}
+                        placeholder="주소"
+                        value={address}
+                        onChangeText={(text) => setAddress(text.trim())}
+                    />
+                    <TextInput
+                        style={styles.input}
+                        placeholder="상세주소"
+                        value={detailedAddress}
+                        onChangeText={(text) => setDetailedAddress(text.trim())}
+                    />
+                    <Text style={styles.helperText}>주소에 이모티콘은 사용할 수 없습니다.</Text>
+                </View>
 
-            {/* 하단 버튼 */}
-            <View style={styles.footer}>
-                <TouchableOpacity
-                    style={[
-                        styles.nextButton,
-                        {
-                            backgroundColor: 
-                            isNextButtonEnabled || isSkipButtonEnabled
-                                ? Colors.orange100
-                                : Colors.gray200,
-                        },
-                    ]}
-                    disabled={!isNextButtonEnabled && !isSkipButtonEnabled}
-                    onPress={() => {
-                        if (isNextButtonEnabled) {
-                            router.push('/login/signup/loginSuccess'); // 다음 화면으로 이동 제작 후 수정(메인화면)
-                        } else if (isSkipButtonEnabled) {
-                            router.push('/login/signup/loginSuccess'); // 건너뛰기 로직 추가
-                        }
-                    }}
-                >
-                    <Text style={styles.nextButtonText}>
-                        {isNextButtonEnabled ? '다음' : '건너뛰기'}
-                    </Text>
-                </TouchableOpacity>
-            </View>
-        </Container>
+                {/* 하단 버튼 */}
+                <View style={styles.footer}>
+                    <TouchableOpacity
+                        style={[
+                            styles.nextButton,
+                            {
+                                backgroundColor:
+                                    isNextButtonEnabled || isSkipButtonEnabled
+                                        ? Colors.orange100
+                                        : Colors.gray200,
+                            },
+                        ]}
+                        disabled={!isNextButtonEnabled && !isSkipButtonEnabled}
+                        onPress={() => {
+                            if (isNextButtonEnabled) {
+                                router.push('/login/signup/loginSuccess'); // 다음 화면으로 이동 제작 후 수정(메인화면)
+                            } else if (isSkipButtonEnabled) {
+                                router.push('/login/signup/loginSuccess'); // 건너뛰기 로직 추가
+                            }
+                        }}
+                    >
+                        <Text style={styles.nextButtonText}>
+                            {isNextButtonEnabled ? '다음' : '건너뛰기'}
+                        </Text>
+                    </TouchableOpacity>
+                </View>
+            </KeyboardAvoidingView>
+        </TouchableWithoutFeedback>
     );
 };
 
 const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+        padding: 20,
+        justifyContent: 'space-between'
+      },
     header: {
+        marginTop: 20,
         position: 'absolute',
         top: 20,
         left: 20,
@@ -104,9 +116,8 @@ const styles = StyleSheet.create({
     },
     addressSection: {
         flex: 1,
-        justifyContent: 'flex-start', // 위치 조정 가능
+        justifyContent: 'center', // 위치 조정 가능
         alignItems: 'center',
-        marginTop: 300,
     },
     label: {
         ...Typography.body.large_bold,

--- a/app/login/signup/loginAddress.jsx
+++ b/app/login/signup/loginAddress.jsx
@@ -1,0 +1,152 @@
+import React, { useState } from 'react';
+import {
+    View,
+    Text,
+    TextInput,
+    TouchableOpacity,
+    StyleSheet,
+} from 'react-native';
+import { useRouter } from 'expo-router';
+import { MaterialIcons } from '@expo/vector-icons';
+import Colors from '../../../src/styles/color';
+import Typography from '../../../src/styles/typhography';
+import { STRINGS } from '../../../src/config/string';
+import Container from '../../../src/components/container';
+
+const MIN_ADDRESS_LENGTH = 0;
+
+const AddressInput = () => {
+    const [address, setAddress] = useState('');
+    const [detailedAddress, setDetailedAddress] = useState('');
+    const router = useRouter();
+
+    const isNextButtonEnabled = address.length > MIN_ADDRESS_LENGTH && detailedAddress.length > MIN_ADDRESS_LENGTH;
+    const isSkipButtonEnabled = address.length === MIN_ADDRESS_LENGTH && detailedAddress.length === MIN_ADDRESS_LENGTH;
+
+    return (
+        <Container>
+            {/* 상단 네비게이션 */}
+            <View style={styles.header}>
+                <TouchableOpacity style={styles.backButton} onPress={() => router.back()}>
+                    <MaterialIcons name="arrow-back" size={24} color={Colors.gray500} />
+                </TouchableOpacity>
+                <Text style={styles.headerTitle}>{STRINGS.SIGNUP.TITLE}</Text>
+                <Text style={styles.pageIndicator}>3 / 3</Text>
+            </View>
+
+            {/* 주소 입력 */}
+            <View style={styles.addressSection}>
+                <Text style={styles.label}>주소</Text>
+                <TextInput
+                    style={styles.input}
+                    placeholder="주소"
+                    value={address}
+                    onChangeText={(text) => setAddress(text.trim())}
+                />
+                <TextInput
+                    style={styles.input}
+                    placeholder="상세주소"
+                    value={detailedAddress}
+                    onChangeText={(text) => setDetailedAddress(text.trim())}
+                />
+                <Text style={styles.helperText}>주소에 이모티콘은 사용할 수 없습니다.</Text>
+            </View>
+
+            {/* 하단 버튼 */}
+            <View style={styles.footer}>
+                <TouchableOpacity
+                    style={[
+                        styles.nextButton,
+                        {
+                            backgroundColor: 
+                            isNextButtonEnabled || isSkipButtonEnabled
+                                ? Colors.orange100
+                                : Colors.gray200,
+                        },
+                    ]}
+                    disabled={!isNextButtonEnabled && !isSkipButtonEnabled}
+                    onPress={() => {
+                        if (isNextButtonEnabled) {
+                            router.push('/login/signup/loginSuccess'); // 다음 화면으로 이동 제작 후 수정(메인화면)
+                        } else if (isSkipButtonEnabled) {
+                            router.push('/login/signup/loginSuccess'); // 건너뛰기 로직 추가
+                        }
+                    }}
+                >
+                    <Text style={styles.nextButtonText}>
+                        {isNextButtonEnabled ? '다음' : '건너뛰기'}
+                    </Text>
+                </TouchableOpacity>
+            </View>
+        </Container>
+    );
+};
+
+const styles = StyleSheet.create({
+    header: {
+        position: 'absolute',
+        top: 20,
+        left: 20,
+        right: 20,
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+    },
+    backButton: {
+        padding: 5,
+    },
+    headerTitle: {
+        ...Typography.heading.small_bold,
+    },
+    pageIndicator: {
+        ...Typography.heading.small_bold,
+        color: Colors.orange100,
+    },
+    addressSection: {
+        flex: 1,
+        justifyContent: 'flex-start', // 위치 조정 가능
+        alignItems: 'center',
+        marginTop: 300,
+    },
+    label: {
+        ...Typography.body.large_bold,
+        marginBottom: 8,
+        alignSelf: 'flex-start',
+    },
+    input: {
+        height: 60,
+        borderWidth: 1,
+        borderColor: Colors.orange100,
+        borderRadius: 5,
+        paddingHorizontal: 10,
+        marginBottom: 10,
+        width: '100%',
+    },
+    helperText: {
+        marginTop: 10,
+        ...Typography.body.medium,
+        color: Colors.gray300,
+        textAlign: 'center',
+    },
+    footer: {
+        position: 'absolute',
+        bottom: 20,
+        left: 20,
+        right: 20,
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+    nextButton: {
+        height: 50,
+        justifyContent: 'center',
+        alignItems: 'center',
+        borderRadius: 5,
+        width: '100%',
+    },
+    nextButtonText: {
+        ...Typography.body.large_bold,
+        color: Colors.gray500,
+    },
+});
+
+export default AddressInput;

--- a/app/login/signup/loginEmail.jsx
+++ b/app/login/signup/loginEmail.jsx
@@ -5,6 +5,10 @@ import {
   TextInput,
   TouchableOpacity,
   StyleSheet,
+  KeyboardAvoidingView,
+  Platform,
+  TouchableWithoutFeedback,
+  Keyboard
 } from 'react-native';
 import { useRouter } from 'expo-router';
 import { MaterialIcons } from '@expo/vector-icons';
@@ -30,63 +34,71 @@ const LoginEmail = () => {
   const isNextButtonEnabled = EMAIL_REGEX.test(email); // 이메일 양식 검사
 
   return (
-    <Container>
-      {/* 상단 네비게이션 */}
-      <View style={styles.header}>
-        <TouchableOpacity style={styles.backButton} onPress={() => router.back()}>
-          <MaterialIcons name="arrow-back" size={24} color={Colors.gray500} />
-        </TouchableOpacity>
-        <Text style={styles.headerTitle}>{STRINGS.SIGNUP.TITLE}</Text>
-        <Text style={styles.pageIndicator}>2 / 3</Text>
-      </View>
+    <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+      <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : 'height'} style={styles.container}>
+        {/* 상단 네비게이션 */}
+        <View style={styles.header}>
+          <TouchableOpacity style={styles.backButton} onPress={() => router.back()}>
+            <MaterialIcons name="arrow-back" size={24} color={Colors.gray500} />
+          </TouchableOpacity>
+          <Text style={styles.headerTitle}>{STRINGS.SIGNUP.TITLE}</Text>
+          <Text style={styles.pageIndicator}>2 / 3</Text>
+        </View>
 
-      {/* 이메일 입력 */}
-      <View style={styles.emailSection}>
-        <Text style={styles.label}>이메일</Text>
-        <TextInput
-          style={styles.input}
-          placeholder="이메일"
-          value={email}
-          onChangeText={handleEmailChange}
-          keyboardType="email-address"
-        />
-        <Text style={styles.helperText}>이메일 양식에 맞춰 작성해주세요.</Text>
-      </View>
+        {/* 이메일 입력 */}
+        <View style={styles.emailSection}>
+          <Text style={styles.label}>이메일</Text>
+          <TextInput
+            style={styles.input}
+            placeholder="이메일"
+            value={email}
+            onChangeText={handleEmailChange}
+            keyboardType="email-address"
+          />
+          <Text style={styles.helperText}>이메일 양식에 맞춰 작성해주세요.</Text>
+        </View>
 
-      {/* 하단 버튼 */}
-      <View style={styles.footer}>
-        <TouchableOpacity
-          style={[
-            styles.nextButton,
-            {
-              backgroundColor:
-                email.length === MIN_EMAIL_LENGTH || isNextButtonEnabled
-                  ? Colors.orange100
-                  : Colors.gray200,
-            },
-          ]}
-          disabled={email.length > MIN_EMAIL_LENGTH && !isNextButtonEnabled}
-          onPress={() => {
-            if (isNextButtonEnabled || email.length === MIN_EMAIL_LENGTH) {
-              router.push('/login/signup/loginAddress'); 
-            }
-          }}
-        >
-          <Text style={styles.nextButtonText}>
-            {email.length === MIN_EMAIL_LENGTH
-              ? '건너뛰기'
-              : isNextButtonEnabled
-              ? '다음'
-              : '건너뛰기'}
-          </Text>
-        </TouchableOpacity>
-      </View>
-    </Container>
+        {/* 하단 버튼 */}
+        <View style={styles.footer}>
+          <TouchableOpacity
+            style={[
+              styles.nextButton,
+              {
+                backgroundColor:
+                  email.length === MIN_EMAIL_LENGTH || isNextButtonEnabled
+                    ? Colors.orange100
+                    : Colors.gray200,
+              },
+            ]}
+            disabled={email.length > MIN_EMAIL_LENGTH && !isNextButtonEnabled}
+            onPress={() => {
+              if (isNextButtonEnabled || email.length === MIN_EMAIL_LENGTH) {
+                router.push('/login/signup/loginAddress');
+              }
+            }}
+          >
+            <Text style={styles.nextButtonText}>
+              {email.length === MIN_EMAIL_LENGTH
+                ? '건너뛰기'
+                : isNextButtonEnabled
+                  ? '다음'
+                  : '건너뛰기'}
+            </Text>
+          </TouchableOpacity>
+        </View>
+      </KeyboardAvoidingView>
+    </TouchableWithoutFeedback>
   );
 };
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 20,
+    justifyContent: 'space-between'
+  },
   header: {
+    marginTop: 20,
     position: 'absolute',
     top: 20,
     left: 20,
@@ -107,9 +119,8 @@ const styles = StyleSheet.create({
   },
   emailSection: {
     flex: 1,
-    justifyContent: 'flex-start', // 수직 위치 조정
+    justifyContent: 'center', // 수직 위치 조정
     alignItems: 'center',         // 수평 위치 중앙
-    marginTop: 300,                // 원하는 여백 추가
   },
   label: {
     ...Typography.body.large_bold,

--- a/app/login/signup/loginEmail.jsx
+++ b/app/login/signup/loginEmail.jsx
@@ -1,0 +1,154 @@
+import React, { useState } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  StyleSheet,
+} from 'react-native';
+import { useRouter } from 'expo-router';
+import { MaterialIcons } from '@expo/vector-icons';
+import Colors from '../../../src/styles/color';
+import Typography from '../../../src/styles/typhography';
+import { STRINGS } from '../../../src/config/string';
+import Container from '../../../src/components/container';
+
+// 상수 정의
+const MIN_EMAIL_LENGTH = 0;
+
+// 이메일 유효성 검사 정규식
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const LoginEmail = () => {
+  const [email, setEmail] = useState('');
+  const router = useRouter();
+
+  const handleEmailChange = (text) => {
+    setEmail(text.trim()); // 공백 제거
+  };
+
+  const isNextButtonEnabled = EMAIL_REGEX.test(email); // 이메일 양식 검사
+
+  return (
+    <Container>
+      {/* 상단 네비게이션 */}
+      <View style={styles.header}>
+        <TouchableOpacity style={styles.backButton} onPress={() => router.back()}>
+          <MaterialIcons name="arrow-back" size={24} color={Colors.gray500} />
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>{STRINGS.SIGNUP.TITLE}</Text>
+        <Text style={styles.pageIndicator}>2 / 3</Text>
+      </View>
+
+      {/* 이메일 입력 */}
+      <View style={styles.emailSection}>
+        <Text style={styles.label}>이메일</Text>
+        <TextInput
+          style={styles.input}
+          placeholder="이메일"
+          value={email}
+          onChangeText={handleEmailChange}
+          keyboardType="email-address"
+        />
+        <Text style={styles.helperText}>이메일 양식에 맞춰 작성해주세요.</Text>
+      </View>
+
+      {/* 하단 버튼 */}
+      <View style={styles.footer}>
+        <TouchableOpacity
+          style={[
+            styles.nextButton,
+            {
+              backgroundColor:
+                email.length === MIN_EMAIL_LENGTH || isNextButtonEnabled
+                  ? Colors.orange100
+                  : Colors.gray200,
+            },
+          ]}
+          disabled={email.length > MIN_EMAIL_LENGTH && !isNextButtonEnabled}
+          onPress={() => {
+            if (isNextButtonEnabled || email.length === MIN_EMAIL_LENGTH) {
+              router.push('/login/signup/loginAddress'); 
+            }
+          }}
+        >
+          <Text style={styles.nextButtonText}>
+            {email.length === MIN_EMAIL_LENGTH
+              ? '건너뛰기'
+              : isNextButtonEnabled
+              ? '다음'
+              : '건너뛰기'}
+          </Text>
+        </TouchableOpacity>
+      </View>
+    </Container>
+  );
+};
+
+const styles = StyleSheet.create({
+  header: {
+    position: 'absolute',
+    top: 20,
+    left: 20,
+    right: 20,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  backButton: {
+    padding: 5,
+  },
+  headerTitle: {
+    ...Typography.heading.small_bold,
+  },
+  pageIndicator: {
+    ...Typography.heading.small_bold,
+    color: Colors.orange100,
+  },
+  emailSection: {
+    flex: 1,
+    justifyContent: 'flex-start', // 수직 위치 조정
+    alignItems: 'center',         // 수평 위치 중앙
+    marginTop: 300,                // 원하는 여백 추가
+  },
+  label: {
+    ...Typography.body.large_bold,
+    marginBottom: 8,
+    alignSelf: 'flex-start',
+  },
+  input: {
+    height: 60,
+    borderWidth: 1,
+    borderColor: Colors.orange100,
+    borderRadius: 5,
+    paddingHorizontal: 10,
+    marginRight: 10,
+    width: '100%',
+  },
+  helperText: {
+    marginTop: 10,
+    ...Typography.body.medium,
+    color: Colors.gray300,
+  },
+  footer: {
+    position: 'absolute',
+    bottom: 20,
+    left: 20,
+    right: 20,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  nextButton: {
+    height: 50,
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderRadius: 5,
+    width: '100%',
+  },
+  nextButtonText: {
+    ...Typography.body.large_bold,
+    color: Colors.gray500,
+  },
+});
+
+export default LoginEmail;

--- a/app/login/signup/loginNickname.jsx
+++ b/app/login/signup/loginNickname.jsx
@@ -6,13 +6,16 @@ import {
   TouchableOpacity,
   StyleSheet,
   Alert,
+  KeyboardAvoidingView,
+  Platform,
+  TouchableWithoutFeedback,
+  Keyboard
 } from 'react-native';
 import { useRouter } from 'expo-router';
 import { MaterialIcons } from '@expo/vector-icons';
 import Colors from '../../../src/styles/color';
 import Typography from '../../../src/styles/typhography';
 import { STRINGS } from '../../../src/config/string';
-import Container from '../../../src/components/container';
 
 // 상수 정의
 const MIN_NICKNAME_LENGTH = 4;
@@ -42,69 +45,78 @@ const LoginNickname = () => {
   const isNextButtonEnabled = isDuplicateChecked;
 
   return (
-    <Container>
-      {/* 상단 네비게이션 */}
-      <View style={styles.header}>
-        <TouchableOpacity style={styles.backButton} onPress={() => router.back()}>
-          <MaterialIcons name='arrow-back' size={24} color={Colors.gray500} />
-        </TouchableOpacity>
-        <Text style={styles.headerTitle}>{STRINGS.SIGNUP.TITLE}</Text>
-        <Text style={styles.pageIndicator}>1 / 3</Text>
-      </View>
+    <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+      <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : 'height'} style={styles.container}>
+        {/* 상단 네비게이션 */}
+        <View style={styles.header}>
+          <TouchableOpacity style={styles.backButton} onPress={() => router.back()}>
+            <MaterialIcons name='arrow-back' size={24} color={Colors.gray500} />
+          </TouchableOpacity>
+          <Text style={styles.headerTitle}>{STRINGS.SIGNUP.TITLE}</Text>
+          <Text style={styles.pageIndicator}>1 / 3</Text>
+        </View>
 
-      {/* 닉네임 입력 */}
-      <View style={styles.nicknameSection}>
-        <Text style={styles.label}>닉네임</Text>
-        <View style={styles.inputRow}>
-          <TextInput
-            style={styles.input}
-            placeholder="닉네임"
-            value={nickname}
-            onChangeText={handleNicknameChange}
-          />
+        {/* 닉네임 입력 */}
+        <View style={styles.nicknameSection}>
+          <Text style={styles.label}>닉네임</Text>
+          <View style={styles.inputRow}>
+            <TextInput
+              style={styles.input}
+              placeholder="닉네임"
+              value={nickname}
+              onChangeText={handleNicknameChange}
+            />
+            <TouchableOpacity
+              style={[
+                styles.duplicateCheckButton,
+                { backgroundColor: nickname.length >= MIN_NICKNAME_LENGTH ? Colors.orange100 : Colors.gray200 },
+              ]}
+              onPress={handleDuplicateCheck}
+              disabled={nickname.length < MIN_NICKNAME_LENGTH}
+            >
+              <Text style={styles.duplicateCheckText}>중복 체크</Text>
+            </TouchableOpacity>
+          </View>
+          <Text style={styles.helperText}>
+            닉네임은 이모티콘 제외 4~10글자로 만들어주세요
+          </Text>
+        </View>
+
+        {/* 하단 버튼 */}
+        <View style={styles.footer}>
           <TouchableOpacity
             style={[
-              styles.duplicateCheckButton,
-              { backgroundColor: nickname.length >= MIN_NICKNAME_LENGTH ? Colors.orange100 : Colors.gray200 },
+              styles.nextButton,
+              {
+                backgroundColor: isNextButtonEnabled ? Colors.orange100 : Colors.gray200,
+              },
             ]}
-            onPress={handleDuplicateCheck}
-            disabled={nickname.length < MIN_NICKNAME_LENGTH}
+            disabled={!isNextButtonEnabled}
+            onPress={() => {
+              if (isNextButtonEnabled) {
+                router.push('/login/signup/loginEmail');
+              }
+            }}
           >
-            <Text style={styles.duplicateCheckText}>중복 체크</Text>
+            <Text style={styles.nextButtonText}>
+              {isNextButtonEnabled ? '다음' : '건너뛰기'}
+            </Text>
           </TouchableOpacity>
         </View>
-        <Text style={styles.helperText}>
-          닉네임은 이모티콘 제외 4~10글자로 만들어주세요
-        </Text>
-      </View>
-
-      {/* 하단 버튼 */}
-      <View style={styles.footer}>
-        <TouchableOpacity
-          style={[
-            styles.nextButton,
-            {
-              backgroundColor: isNextButtonEnabled ? Colors.orange100 : Colors.gray200,
-            },
-          ]}
-          disabled={!isNextButtonEnabled}
-          onPress={() => {
-            if (isNextButtonEnabled) {
-              router.push('/login/signup/loginEmail');
-            }
-          }}
-        >
-          <Text style={styles.nextButtonText}>
-            {isNextButtonEnabled ? '다음' : '건너뛰기'}
-          </Text>
-        </TouchableOpacity>
-      </View>
-    </Container>
+        {/* </TouchableWithoutFeedback> */}
+      </KeyboardAvoidingView>
+    </TouchableWithoutFeedback>
   );
 };
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 20,
+    justifyContent: 'space-between'
+  },
   header: {
+    marginTop: 20,
     position: 'absolute',
     top: 20,
     left: 20,
@@ -125,10 +137,9 @@ const styles = StyleSheet.create({
   },
   nicknameSection: {
     flex: 1,
-    justifyContent: 'flex-start', // 수직 위치 조정
-    alignItems: 'center',         // 수평 위치 중앙
-    marginTop: 300,                // 원하는 여백 추가
-  }, 
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
   label: {
     ...Typography.body.large_bold,
     marginBottom: 8,

--- a/app/login/signup/loginNickname.jsx
+++ b/app/login/signup/loginNickname.jsx
@@ -90,7 +90,7 @@ const LoginNickname = () => {
           disabled={!isNextButtonEnabled}
           onPress={() => {
             if (isNextButtonEnabled) {
-              router.push('/nextStep'); // 다음화면 제작 후 수정할 것
+              router.push('/login/signup/loginEmail');
             }
           }}
         >

--- a/app/login/signup/loginSuccess.jsx
+++ b/app/login/signup/loginSuccess.jsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+  Image,
+} from 'react-native';
+import { useRouter } from 'expo-router';
+import { MaterialIcons } from '@expo/vector-icons';
+import Colors from '../../../src/styles/color';
+import Typography from '../../../src/styles/typhography';
+
+const SignupComplete = () => {
+  const router = useRouter();
+
+  return (
+    <View style={styles.container}>
+      {/* 상단 완료 아이콘 */}
+      <View style={styles.iconWrapper}>
+        <View style={styles.iconCircle}>
+          <MaterialIcons name='check' size={70} color={Colors.white}/>
+        </View>
+      </View>
+
+      {/* 완료 메시지 */}
+      <Text style={styles.completeText}>회원가입 완료!</Text>
+      <Text style={styles.subText}>내 주변 붕어빵 매장을 찾으러 가볼까요?</Text>
+
+      {/* 하단 버튼 */}
+      <TouchableOpacity
+        style={styles.startButton}
+        onPress={() => router.push('(tabs)/boongtam') /* 메인화면으로 이동 */}
+      >
+        <Text style={styles.startButtonText}>붕어탐정 시작하기</Text>
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 20,
+    backgroundColor: Colors.white,
+  },
+  iconWrapper: {
+    marginBottom: 30,
+  },
+  iconCircle: {
+    width: 100,
+    height: 100,
+    borderRadius: 50,
+    backgroundColor: Colors.orange100,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  iconText: {
+    fontSize: 40,
+    color: Colors.white,
+  },
+  completeText: {
+    ...Typography.body.large_bold,
+    marginBottom: 10,
+    textAlign: 'center',
+  },
+  subText: {
+    ...Typography.body.large_bold,
+    color: Colors.gray500,
+    textAlign: 'center',
+    marginBottom: 50,
+  },
+  startButton: {
+    position: 'absolute',
+    bottom: 20,
+    left: 20,
+    right: 20,
+    height: 50,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: Colors.orange100,
+    borderRadius: 5,
+  },
+  startButtonText: {
+    ...Typography.body.large_bold,
+    color: Colors.gray500,
+  },
+});
+
+export default SignupComplete;


### PR DESCRIPTION
카카오 로그인 버튼 클릭 후 추가 입력 화면 추가 완료

1. 이메일 작성화면
1-1. 이메일 작성칸에 내용을 입력하지 않을 시 건너뛰기 버튼 활성화
1-2. 이메일 작성칸에 이메일 작성 시(이메일양식x) 건너뛰기 버튼 비활성화
1-3. 이메일 작성칸에 이메일 작성 시(이메일양식o) 다음 버튼 활성화

2. 주소 작성 화면(주소 입력 2칸)
2-1. 주소 작성칸(주소, 상세주소)에 내용을 입력하지 않을 시 건너뛰기 버튼 활성화
2-2. 주소 작성칸(주소, 상세주소)에 한칸에만 작성 시 건너뛰기 버튼 비활성화
2-3. 주소 작성칸(주소, 상세주소)에 둘다 작성시 다음 버튼 활성화

3. 회원가입 완료 화면
3-1. 주소입력까지 완료시 나오는 화면 '붕어탐정 시작하기' 버튼 클릭 시 메인화면으로 이동 예정 

4. 기존 login.jsx에서 카카오 로그인 버튼 클릭시 이동하는 코드 수정
5. loginNickname.jsx에서 다음 버튼 클릭시 loginEmail.jsx로 이동 하는 코드 수정

브랜치 정보
BT-77